### PR TITLE
Added support for Mojolicious >= 8.42

### DIFF
--- a/lib/Mojo/SAML/Entity.pm
+++ b/lib/Mojo/SAML/Entity.pm
@@ -42,7 +42,11 @@ sub certificate_for {
   my $attr = ':not([use])';
   if (defined $use) {
     Carp::croak "Unknown certificate use $use" unless exists $uses{$use};
-    $attr = qq!:matches([use="$use"], $attr)!;
+    if ($Mojolicious::VERSION >= 8.42) {
+      $attr = qq!:is([use="$use"], $attr)!;
+    } else {
+      $attr = qq!:matches([use="$use"], $attr)!;
+    }
   }
   require Crypt::OpenSSL::X509;
   my $s = qq!md|KeyDescriptor$attr > ds|KeyInfo > ds|X509Data > ds|X509Certificate!;


### PR DESCRIPTION
From Mojolicious 8.42 the ``:matches()`` pseudo-class is renamed in ``:is()`` in  ``Mojo::DOM::CSS``